### PR TITLE
Allow dev user to sign-in using credentials

### DIFF
--- a/app/env.ts
+++ b/app/env.ts
@@ -24,6 +24,9 @@ export const env = createEnv({
    * 💡 You'll get type errors if these are not prefixed with NEXT_PUBLIC_.
    */
   client: {},
+  shared: {
+    NODE_ENV: z.string(),
+  },
   /*
    * Due to how Next.js bundles environment variables on Edge and Client,
    * we need to manually destructure them to make sure all are included in bundle.
@@ -31,6 +34,7 @@ export const env = createEnv({
    * 💡 You'll get type errors if not all variables from `server` & `client` are included here.
    */
   runtimeEnv: {
+    NODE_ENV: process.env.NODE_ENV,
     GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
     GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
     GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID,


### PR DESCRIPTION
Allows user to sign-in using credentials when running locally. This allows developer to bypass Oauth, which requires a callback function.

Code copied from downstream Galoy repo.